### PR TITLE
Update action to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: ./dist/index.js
 
 branding:


### PR DESCRIPTION
## Description

Node 16 reached end-of-life on 11 Sep 2023 (See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).
This PR updates the default runtime from `node16` to `node20`.

This should fix the following warning:

![image](https://github.com/alessiodionisi/setup-age-action/assets/3949095/1d8ec704-052b-44fc-aa63-92500ecb893b)
